### PR TITLE
Update es.yml

### DIFF
--- a/lib/payday/locale/es.yml
+++ b/lib/payday/locale/es.yml
@@ -1,16 +1,16 @@
 es:
   payday: 
     status: 
-      overdue: RETRASADO
-      paid: PAGADO
-      refunded: REINTEGRADO
+      overdue: ATRASADA
+      paid: PAGADA
+      refunded: REEMBOLSADA
     invoice:
       title: FACTURA
       bill_to: Facturar a
       invoice_no: "Recibo #:"
       due_date: "Vencimiento:"
       ship_to: Enviar a
-      paid_date: "Pagado en:"
+      paid_date: "Pagada el:"
       subtotal: "Subtotal:"
       shipping: "Envío:"
       tax: "Impuesto:"
@@ -20,4 +20,4 @@ es:
       description: Descripción
       unit_price: Precio por Unidad
       quantity: Cantidad
-      amount: Cantidad
+      amount: Precio


### PR DESCRIPTION
Fixed various aspects of the translation. 
1. Status where all in masculine form, but the thing we are referencing is a "factura" which is a feminine word, thus the change to A's at the end.
2. The word for overdue: was originally set to "retrasado" which is funny because that's not the right word, and in context can even mean retarded . 
3. They used another strange word for reimbursed and for amount. Fixed those.
4. Paid date was changed from "pagado en" to the correct "pagada el" format.
